### PR TITLE
Update vm2 and turret auth sequence

### DIFF
--- a/serverless/src/app.js
+++ b/serverless/src/app.js
@@ -64,7 +64,6 @@ export default async (event) => {
     })
 
     const result = await vm.run(`
-      'use strict'; 
       ${txFunctionCode};
     `, 'vm.js')(body)
 

--- a/wrangler/src/txFunctions/run.js
+++ b/wrangler/src/txFunctions/run.js
@@ -131,15 +131,22 @@ export default async ({ request, params, env }) => {
     }
   })
 
-  if (error) return response.json({
-    ...error,
-    cost,
-    feeSponsor: authedPublicKey,
-    feeBalanceRemaining,
-  }, {
-    status: error.status,
-    stopwatch: watch,
-  })
+  if (error) {
+    // clear turret auth token cache on an auth failure 
+    if (error.status === 403) {
+      await META.delete('TURRET_AUTH_TOKEN')
+    }
+
+    return response.json({
+      ...error,
+      cost,
+      feeSponsor: authedPublicKey,
+      feeBalanceRemaining,
+    }, {
+      status: error.status,
+      stopwatch: watch,
+    })
+  }
 
   const transaction = new Transaction(xdr, Networks[STELLAR_NETWORK])
 


### PR DESCRIPTION
`use strict`, and wepacked bundles with bable-loader have some disagreements.

VM2's `useStrict = true` appears to do the same thing as prefixing a stript with `use strict`; does.

Secondly, update the turret auth sequence to delete its cached auth token in the event the serverless lambda throws a 403. This means the next call will refresh the auth token.