### PR TITLE
Add support for single use auth tokens

### DIFF
--- a/wrangler/src/@utils/auth.js
+++ b/wrangler/src/@utils/auth.js
@@ -11,19 +11,18 @@ import { verifyTxSignedBy } from './stellar-sdk-utils'
  * 
  * @param {string} network The Stellar Network to validate the token on
  * @param {string} authToken - The provided auth token
- * @param {string?} dataKey - (Optional) Fetch all ManageData operations such that the key matches this dataKey.
- *                           All ManageData values whose keys match will be included in the data output array.
+ * 
  * @link https://tyvdh.github.io/stellar-tss/#section/Authentication
  * 
  *
  * @typedef {Object} AuthResult
  * @property {string} publicKey - The authenticated public key from the token.
  * @property {string[]} data - The data collected. Returns an empty array if no matching ManageData values are 
- *                             found or no dataKey was provided.
+ *                             found
  *
  * @returns {AuthResult} - The result of the authentication
  */
-export function authTxToken(network, authToken, dataKey) {
+export function authTxToken(network, authToken) {
   try {
     if (authToken === undefined) {
       throw { message: 'Unable to find an auth token' };
@@ -50,23 +49,18 @@ export function authTxToken(network, authToken, dataKey) {
       throw { message: `AuthToken not signed` };
     }
     
-    // fetch dataKey portions
     let enteredData = [];
-    if (dataKey) {
-      for (const op of authTx.operations) {
-        if (op.type === 'manageData' && op.name === dataKey) {
-          let value = op.value.toString();
-          enteredData.push(value);
-        }
-      }
-    }
-
-    // check for singleUse key
     let singleUse = false
+
     for (const op of authTx.operations) {
-      if (op.type === 'manageData' && op.name === 'singleUse') {
+      if (op.type === 'manageData') {
         let value = op.value.toString();
-        singleUse = value === 'true' ? true : false
+
+        if (op.name === 'singleUse')
+          singleUse = value === 'true' ? true : false
+
+        else if (op.name === 'txFunctionHash')
+          enteredData.push(value)
       }
     }
 

--- a/wrangler/src/@utils/do-tx-fees.js
+++ b/wrangler/src/@utils/do-tx-fees.js
@@ -1,13 +1,23 @@
 import { response } from 'cfw-easy-utils'
 import BigNumber from 'bignumber.js'
 import moment from 'moment'
+import Bluebird from 'bluebird'
+
+// TODO:
+  // Better error reporting, use try/catch
 
 export default class TxFees {
   constructor(state, env) {
+    const { META } = env
+
     this.storage = state.storage
+    this.META = META
   }
 
   async fetch(request) {
+    const url = new URL(request.url)
+    const { pathname } = url
+    const [, segment_1] = pathname.split('/')
     const { method } = request
 
     if (typeof this.value !== 'object') {
@@ -19,7 +29,47 @@ export default class TxFees {
       this.value = typeof this.value !== 'object' ? iv : this.value
     }
 
-    if (method === 'POST') {
+    if (segment_1) {
+
+      if (method === 'POST') {
+        const transactionHash = segment_1
+
+        if (!this[transactionHash]) {
+          const iTransactionHash = await this.storage.get(transactionHash) || null
+    
+          this[transactionHash] = this[transactionHash] || iTransactionHash
+        }
+  
+        if (this[transactionHash])
+          return response.json({
+            message: `Auth token has already been used`
+          }, {
+            status: 402
+          })
+  
+        else {
+          this[transactionHash] = 'OK'
+          await this.storage.put(transactionHash, 'OK')
+        }  
+  
+        return response.text('OK')
+      }
+
+      else if (method === 'DELETE') {
+        const publicKey = segment_1
+        const body = await request.json()
+        const deleteCount = await this.storage.delete(body)
+
+        await Bluebird.map(body, (transactionHash) => this.META.delete(`suat:${publicKey}:${transactionHash}`))
+
+        return response.text(deleteCount)
+      }
+
+      else
+        return new Response(null, {status: 404})
+    }
+
+    else if (method === 'POST') {
       const body = await request.json()
 
       this.value.lastModifiedTime = moment.utc().format('x')

--- a/wrangler/src/@utils/flush-single-use-auth-tokens.js
+++ b/wrangler/src/@utils/flush-single-use-auth-tokens.js
@@ -1,0 +1,44 @@
+import { response } from 'cfw-easy-utils'
+import moment from 'moment'
+import { groupBy, map } from 'lodash'
+import { handleResponse } from './fetch'
+import Bluebird from 'bluebird'
+
+export default async function flushSingleUseAuthTokens({ env }) {
+  const { META, TX_FEES } = env
+
+  const { keys } = await META.list({prefix: 'suat:', limit: 100})
+
+  const allExpiredKeys = keys
+  .filter(({metadata}) => moment.utc(metadata, 'X').isBefore())
+  .map(({name}) => {
+    const [, publicKey, transactionHash] = name.split(':')
+
+    return {
+      publicKey,
+      transactionHash
+    }
+  })
+
+  const groupedExpiredKeys = map(groupBy(allExpiredKeys, 'publicKey'), (value, key) => {
+    return {
+      publicKey: key,
+      transactionHashes: map(value, 'transactionHash')
+    }
+  })
+
+  const promiseResponse = await Bluebird.mapSeries(groupedExpiredKeys, ({ publicKey, transactionHashes }) => {
+    const txFeesId = TX_FEES.idFromName(publicKey)
+    const txFeesStub = TX_FEES.get(txFeesId)
+
+    return txFeesStub.fetch(`/${publicKey}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(transactionHashes)
+    }).then(handleResponse)
+  })
+
+  return response.json(promiseResponse)
+}

--- a/wrangler/src/index.js
+++ b/wrangler/src/index.js
@@ -1,6 +1,7 @@
 import { Router } from 'tiny-request-router'
 
 import { parseError } from './@utils/parse'
+import flushSingleUseAuthTokens from './@utils/flush-single-use-auth-tokens'
 
 import TxFees from './@utils/do-tx-fees'
 
@@ -33,6 +34,9 @@ router
 
 router
 .put('/ctrl-accounts/:ctrlAccount', ctrlAccountsHeal)
+
+// router
+// .get('/test', flushSingleUseAuthTokens)
 
 async function handleRequest(request, env, ctx) {
   try {
@@ -90,9 +94,18 @@ async function handleRequest(request, env, ctx) {
   }
 }
 
+function handleScheduled(metadata, env, ctx) {
+  return Promise.all([
+    flushSingleUseAuthTokens({metadata, env, ctx})
+  ])
+}
+
 exports.TxFees = TxFees
 exports.handlers = {
   async fetch(request, env, ctx) {
     return handleRequest(request, env, ctx)
+  },
+  async scheduled(metadata, env, ctx) {
+    return handleScheduled(metadata, env, ctx)
   }
 }

--- a/wrangler/src/txFees/get.js
+++ b/wrangler/src/txFees/get.js
@@ -12,7 +12,7 @@ export default async ({ request, env }) => {
     publicKey: authedPublicKey, 
     data: authedContracts,
     singleUse,
-  } = authTxToken(STELLAR_NETWORK, feeToken, 'txFunctionHash')
+  } = authTxToken(STELLAR_NETWORK, feeToken)
 
   const txFeesId = TX_FEES.idFromName(authedPublicKey)
   const txFeesStub = TX_FEES.get(txFeesId)

--- a/wrangler/src/txFees/get.js
+++ b/wrangler/src/txFees/get.js
@@ -7,7 +7,12 @@ export default async ({ request, env }) => {
 
   const feeToken = request.headers.get('authorization')?.split(' ')?.[1]
 
-  const { publicKey: authedPublicKey } = authTxToken(STELLAR_NETWORK, feeToken)
+  const { 
+    hash: authedHash,
+    publicKey: authedPublicKey, 
+    data: authedContracts,
+    singleUse,
+  } = authTxToken(STELLAR_NETWORK, feeToken, 'txFunctionHash')
 
   const txFeesId = TX_FEES.idFromName(authedPublicKey)
   const txFeesStub = TX_FEES.get(txFeesId)
@@ -18,9 +23,12 @@ export default async ({ request, env }) => {
     throw {status: 404, message: `Fee balance could not be found this turret` }
 
   return response.json({
+    hash: authedHash,
     publicKey: authedPublicKey,
     lastModifiedTime: feeMetadata.lastModifiedTime,
-    balance: feeMetadata.balance
+    balance: feeMetadata.balance,
+    txFunctionHashes: authedContracts,
+    singleUse
   }, {
     headers: {
       'Cache-Control': 'public, max-age=5',

--- a/wrangler/src/txFunctions/run.js
+++ b/wrangler/src/txFunctions/run.js
@@ -4,7 +4,6 @@ import BigNumber from 'bignumber.js'
 
 import { authTxToken } from '../@utils/auth'
 import { handleResponse } from '../@utils/fetch'
-import moment from 'moment'
 
 export default async ({ request, params, env }) => {
   const { 
@@ -38,7 +37,7 @@ export default async ({ request, params, env }) => {
     data: authedContracts,
     singleUse,
     exp
-  } = authTxToken(STELLAR_NETWORK, feeToken, 'txFunctionHash')
+  } = authTxToken(STELLAR_NETWORK, feeToken)
 
   // if no contracts are specified in the auth token, allow any contract to be run
   if (

--- a/wrangler/src/txFunctions/upload.js
+++ b/wrangler/src/txFunctions/upload.js
@@ -1,8 +1,7 @@
 import { response } from 'cfw-easy-utils'
 import shajs from 'sha.js'
 import BigNumber from 'bignumber.js'
-import { Transaction, Keypair, Networks } from 'stellar-base'
-import { find } from 'lodash'
+import { Keypair } from 'stellar-base'
 import { processFeePayment } from '../@utils/stellar-sdk-utils'
 
 export default async ({ request, env }) => {

--- a/wrangler/wrangler.toml.dist
+++ b/wrangler/wrangler.toml.dist
@@ -25,6 +25,9 @@ command = "npm i && npm run build"
 format = "modules"
 main = "./shim.mjs"
 
+[triggers]
+crons = ["*/5 * * * *"]
+
 [durable_objects]
 bindings = [
   { name = "TX_FEES", class_name = "TxFees" }


### PR DESCRIPTION
These new txFees are great, but you know what would make them even better? If we had support for single use tokens! This would allow us to safely "leak" these auth keys to the client side and run all our Turrets collation logic there. Being able to sponsor txFees for users is great but I do believe there's significant value in keeping the Turrets collation logic client side, this will allows support for that.

On the implementation side all you need to do in the txFee transaction is add an additional manageData attribute with a key of `singleUse` and a value of `true`.

Additionally the `timeBounds.maxTime` MUST bet set to <= 1 hour.

Here's a RunKit example: https://runkit.com/tyvdh/614a1856d2888500085d8bfe

On the code side not a whole ton has changed, primarily just the addition of a support mechanic for checking single use tokens with the addition of flushing out these tokens via a simple cron task.